### PR TITLE
run git from content subdirectory

### DIFF
--- a/post_revision.py
+++ b/post_revision.py
@@ -30,7 +30,7 @@ def generate_post_revision(generator):
       continue
     try:
       output = subprocess.check_output('git log --format="%%ai|%%s" %s'\
-          % (path), shell=True)
+          % (path), shell=True, cwd=generator.path)
       output = output.decode() if sys.version_info[0] == 3 else output
       commits = []
       for line in output.split('\n'):


### PR DESCRIPTION
it's possible that the 'content' directory is a separate git repository.
this commit modifies post_revision so that it runs git from inside the
'content' directory.  This will work regardless of whether 'content'
is a separate repository or part of the main project repository.